### PR TITLE
Future-proof a dependency on type inference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ where Self: Copy + Sized + Num + NumCast {
     fn from_iter_radix<I: IntoIterator<Item=Self>>(iter: I, base: i64) -> i64 {
         iter.into_iter().fold(
             0i64,
-            |mut sum: i64, number| {sum *= base; sum += cast(number).unwrap(); sum}
+            |mut sum: i64, number| {sum *= base; sum += cast::<Self,i64>(number).unwrap(); sum}
         )
     }
 }


### PR DESCRIPTION
In the Rust compiler, a pull request is being considered (see GitHub PR rust-lang/rust#41336) that will add support for `a += &b` (instead of only `a += b`) for numeric types like `i64` and `f64`. This helps when writing generic code.

Unfortunately, this breaks the build of rust-num-digitize, because rust-num-digitize currently does the following:

`sum += cast(number).unwrap();`

Rust is currently able to infer that `cast(number)` really means `cast::<Self,i64>(number)`, because it takes a Self and the result gets added to a `i64`. But if the PR on the compiler is accepted, this type inference will no longer be possible, because `cast(number)` could also be `cast::<Self,&'a i64>()` for some lifetime `'a`.

This commit specifies the types used in `cast()` explicitly, so that it doesn't require any type inference.